### PR TITLE
Bernstein yang modular multiplicative inverter

### DIFF
--- a/benches/bn256_field.rs
+++ b/benches/bn256_field.rs
@@ -40,6 +40,9 @@ pub fn bench_bn256_field(c: &mut Criterion) {
     group.bench_function("bn256_fq_square", |bencher| {
         bencher.iter(|| black_box(&a).square())
     });
+    group.bench_function("bn256_fq_invert", |bencher| {
+        bencher.iter(|| black_box(&a).invert())
+    });
 }
 
 criterion_group!(benches, bench_bn256_field);

--- a/src/bernsteinyang.rs
+++ b/src/bernsteinyang.rs
@@ -1,44 +1,45 @@
 use core::cmp::PartialEq;
-use std::ops::{Add, Mul, Sub, Neg};
+use std::ops::{Add, Mul, Neg, Sub};
 
 /// Big signed (B * L)-bit integer type, whose variables store
 /// numbers in the two's complement code as arrays of B-bit chunks.
 /// The ordering of the chunks in these arrays is little-endian.
 /// The arithmetic operations for this type are wrapping ones.
 #[derive(Clone)]
-struct ChunkInt<const B:usize, const L:usize>(pub [u64; L]);
+struct CInt<const B: usize, const L: usize>(pub [u64; L]);
 
-impl<const B:usize, const L:usize> ChunkInt<B,L> {
+impl<const B: usize, const L: usize> CInt<B, L> {
     /// Mask, in which the B lowest bits are 1 and only they
     pub const MASK: u64 = u64::MAX >> (64 - B);
 
-    /// Representation of 0
-    pub const ZERO: Self = Self([0; L]);
-    
-    /// Representation of 1
-    pub const ONE: Self = { 
-        let mut data = [0; L]; 
-        data[0] = 1; Self(data) 
-    };
-
     /// Representation of -1
     pub const MINUS_ONE: Self = Self([Self::MASK; L]);
+
+    /// Representation of 0
+    pub const ZERO: Self = Self([0; L]);
+
+    /// Representation of 1
+    pub const ONE: Self = {
+        let mut data = [0; L];
+        data[0] = 1;
+        Self(data)
+    };
 
     /// Returns the result of applying B-bit right
     /// arithmetical shift to the current number
     pub fn shift(&self) -> Self {
         let mut data = [0; L];
-        for i in 1..L {
-            data[i - 1] = self.0[i];
-        }
         if self.is_negative() {
             data[L - 1] = Self::MASK;
         }
+        data[..L - 1].copy_from_slice(&self.0[1..]);
         Self(data)
     }
 
     /// Returns the lowest B bits of the current number
-    pub fn lowest(&self) -> u64 { self.0[0] }
+    pub fn lowest(&self) -> u64 {
+        self.0[0]
+    }
 
     /// Returns "true" iff the current number is negative
     pub fn is_negative(&self) -> bool {
@@ -46,95 +47,106 @@ impl<const B:usize, const L:usize> ChunkInt<B,L> {
     }
 }
 
-impl <const B:usize, const L:usize> PartialEq for ChunkInt<B,L> {
-    fn eq(&self, other: &Self) -> bool { self.0 == other.0 }
-    fn ne(&self, other: &Self) -> bool { self.0 != other.0 } 
+impl<const B: usize, const L: usize> PartialEq for CInt<B, L> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
 }
 
-impl<const B:usize, const L:usize> Add for &ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Add for &CInt<B, L> {
+    type Output = CInt<B, L>;
     fn add(self, other: Self) -> Self::Output {
         let (mut data, mut carry) = ([0; L], 0);
         for i in 0..L {
             let sum = self.0[i] + other.0[i] + carry;
-            data[i] = sum & ChunkInt::<B,L>::MASK;
+            data[i] = sum & CInt::<B, L>::MASK;
             carry = sum >> B;
         }
         Self::Output { 0: data }
     }
 }
 
-impl<const B:usize, const L:usize> Add<&ChunkInt<B,L>> for ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Add<&CInt<B, L>> for CInt<B, L> {
+    type Output = CInt<B, L>;
     fn add(self, other: &Self) -> Self::Output {
         &self + other
     }
 }
 
-impl<const B:usize, const L:usize> Add for ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Add for CInt<B, L> {
+    type Output = CInt<B, L>;
     fn add(self, other: Self) -> Self::Output {
         &self + &other
     }
 }
 
-impl<const B:usize, const L:usize> Sub for &ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Sub for &CInt<B, L> {
+    type Output = CInt<B, L>;
     fn sub(self, other: Self) -> Self::Output {
+        // For the two's complement code the additive negation is the result of
+        // adding 1 to the bitwise inverted argument's representation. Thus, for
+        // any encoded integers x and y we have x - y = x + !y + 1, where "!" is
+        // the bitwise inversion and addition is done according to the rules of
+        // the code. The algorithm below uses this formula and is the modified
+        // addition algorithm, where the carry flag is initialized with 1 and
+        // the chunks of the second argument are bitwise inverted
         let (mut data, mut carry) = ([0; L], 1);
         for i in 0..L {
-            let sum = self.0[i] + (other.0[i] ^ ChunkInt::<B,L>::MASK) + carry;
-            data[i] = sum & ChunkInt::<B,L>::MASK;
+            let sum = self.0[i] + (other.0[i] ^ CInt::<B, L>::MASK) + carry;
+            data[i] = sum & CInt::<B, L>::MASK;
             carry = sum >> B;
         }
         Self::Output { 0: data }
     }
 }
 
-impl<const B:usize, const L:usize> Sub<&ChunkInt<B,L>> for ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Sub<&CInt<B, L>> for CInt<B, L> {
+    type Output = CInt<B, L>;
     fn sub(self, other: &Self) -> Self::Output {
         &self - other
     }
 }
 
-impl<const B:usize, const L:usize> Sub for ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Sub for CInt<B, L> {
+    type Output = CInt<B, L>;
     fn sub(self, other: Self) -> Self::Output {
         &self - &other
     }
 }
 
-impl<const B:usize, const L:usize> Neg for &ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Neg for &CInt<B, L> {
+    type Output = CInt<B, L>;
     fn neg(self) -> Self::Output {
+        // For the two's complement code the additive negation is the result
+        // of adding 1 to the bitwise inverted argument's representation
         let (mut data, mut carry) = ([0; L], 1);
         for i in 0..L {
-            let sum = (self.0[i] ^ ChunkInt::<B,L>::MASK) + carry;
-            data[i] = sum & ChunkInt::<B,L>::MASK;
+            let sum = (self.0[i] ^ CInt::<B, L>::MASK) + carry;
+            data[i] = sum & CInt::<B, L>::MASK;
             carry = sum >> B;
         }
         Self::Output { 0: data }
     }
 }
 
-impl<const B:usize, const L:usize> Neg for ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Neg for CInt<B, L> {
+    type Output = CInt<B, L>;
     fn neg(self) -> Self::Output {
         -&self
     }
 }
 
-impl<const B:usize, const L:usize> Mul for &ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Mul for &CInt<B, L> {
+    type Output = CInt<B, L>;
     fn mul(self, other: Self) -> Self::Output {
         let mut data = [0; L];
         for i in 0..L {
             let mut carry = 0;
             for k in 0..(L - i) {
-                let sum = (data[i + k] as u128) + (carry as u128) +
-                    (self.0[i] as u128) * (other.0[k] as u128);
-                data[i + k] = sum as u64 & ChunkInt::<B,L>::MASK;
+                let sum = (data[i + k] as u128)
+                    + (carry as u128)
+                    + (self.0[i] as u128) * (other.0[k] as u128);
+                data[i + k] = sum as u64 & CInt::<B, L>::MASK;
                 carry = (sum >> B) as u64;
             }
         }
@@ -142,137 +154,182 @@ impl<const B:usize, const L:usize> Mul for &ChunkInt<B,L> {
     }
 }
 
-impl<const B:usize, const L:usize> Mul<&ChunkInt<B,L>> for ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Mul<&CInt<B, L>> for CInt<B, L> {
+    type Output = CInt<B, L>;
     fn mul(self, other: &Self) -> Self::Output {
         &self * other
     }
 }
 
-impl<const B:usize, const L:usize> Mul for ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Mul for CInt<B, L> {
+    type Output = CInt<B, L>;
     fn mul(self, other: Self) -> Self::Output {
         &self * &other
     }
 }
 
-impl<const B:usize, const L:usize> Mul<i64> for &ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Mul<i64> for &CInt<B, L> {
+    type Output = CInt<B, L>;
     fn mul(self, other: i64) -> Self::Output {
         let mut data = [0; L];
-        let (other, mut carry, mask) = if other < 0 { 
-            (-other, -other as u64, ChunkInt::<B,L>::MASK) 
-        } else { (other, 0, 0) };
+        // If the short multiplicand is non-negative, the standard multiplication
+        // algorithm is performed. Otherwise, the product of the additively negated
+        // multiplicands is found as follows. Since for the two's complement code
+        // the additive negation is the result of adding 1 to the bitwise inverted
+        // argument's representation, for any encoded integers x and y we have
+        // x * y = (-x) * (-y) = (!x + 1) * (-y) = !x * (-y) + (-y),  where "!" is
+        // the bitwise inversion and arithmetic operations are performed according
+        // to the rules of the code. If the short multiplicand is negative, the
+        // algorithm below uses this formula by substituting the short multiplicand
+        // for y and turns into the modified standard multiplication algorithm,
+        // where the carry flag is initialized with the additively negated short
+        // multiplicand and the chunks of the long multiplicand are bitwise inverted
+        let (other, mut carry, mask) = if other < 0 {
+            (-other, -other as u64, CInt::<B, L>::MASK)
+        } else {
+            (other, 0, 0)
+        };
         for i in 0..L {
             let sum = (carry as u128) + ((self.0[i] ^ mask) as u128) * (other as u128);
-            data[i] = sum as u64 & ChunkInt::<B,L>::MASK;
+            data[i] = sum as u64 & CInt::<B, L>::MASK;
             carry = (sum >> B) as u64;
         }
         Self::Output { 0: data }
     }
 }
 
-impl<const B:usize, const L:usize> Mul<i64> for ChunkInt<B,L> {
-    type Output = ChunkInt<B,L>;
+impl<const B: usize, const L: usize> Mul<i64> for CInt<B, L> {
+    type Output = CInt<B, L>;
     fn mul(self, other: i64) -> Self::Output {
         &self * other
     }
 }
 
-impl<const B:usize, const L:usize> Mul<&ChunkInt<B,L>> for i64 {
-    type Output = ChunkInt<B,L>;
-    fn mul(self, other: &ChunkInt<B,L>) -> Self::Output {
-        other * self 
+impl<const B: usize, const L: usize> Mul<&CInt<B, L>> for i64 {
+    type Output = CInt<B, L>;
+    fn mul(self, other: &CInt<B, L>) -> Self::Output {
+        other * self
     }
 }
 
-impl<const B:usize, const L:usize> Mul<ChunkInt<B,L>> for i64 {
-    type Output = ChunkInt<B,L>;
-    fn mul(self, other: ChunkInt<B,L>) -> Self::Output {
-        other * self 
+impl<const B: usize, const L: usize> Mul<CInt<B, L>> for i64 {
+    type Output = CInt<B, L>;
+    fn mul(self, other: CInt<B, L>) -> Self::Output {
+        other * self
     }
 }
 
 /// Type of the modular multiplicative inverter based on the Bernstein-Yang method.
-/// The inverter can be created for a specified modulus M and adjusting parameter A 
-/// to compute the adjusted multiplicative inverses of positive integers, i.e. for 
-/// computing (1 / x) * A mod M for a positive integer x.
+/// The inverter can be created for a specified modulus M and adjusting parameter A
+/// to compute the adjusted multiplicative inverses of positive integers, i.e. for
+/// computing (1 / x) * A (mod M) for a positive integer x.
 ///
 /// The adjusting parameter allows computing the multiplicative inverses in the case of
-/// using the Montgomery representation for the input or the expected output. If R is 
+/// using the Montgomery representation for the input or the expected output. If R is
 /// the Montgomery factor, the multiplicative inverses in the appropriate representation
 /// can be computed provided that the value of A is chosen as follows:
-/// - A = 1, if both the input and the expected output are in the trivial form
+/// - A = 1, if both the input and the expected output are in the standard form
 /// - A = R^2 mod M, if both the input and the expected output are in the Montgomery form
 /// - A = R mod M, if either the input or the expected output is in the Montgomery form,
 /// but not both of them
-/// 
+///
 /// The public methods of this type receive and return unsigned big integers as arrays of
 /// 64-bit chunks, the ordering of which is little-endian. Both the modulus and the integer
-/// to be inverted should not exceed 2 ^ (B * (L - 1) - 2)
-pub struct BYInverter<const B:usize, const L:usize> {
+/// to be inverted should not exceed 2 ^ (62 * L - 64)
+///
+/// For better understanding the implementation, the following resources are recommended:
+/// - D. Bernstein, B.-Y. Yang, "Fast constant-time gcd computation and modular inversion",
+/// https://gcd.cr.yp.to/safegcd-20190413.pdf
+/// - P. Wuille, "The safegcd implementation in libsecp256k1 explained",
+/// https://github.com/bitcoin-core/secp256k1/blob/master/doc/safegcd_implementation.md
+pub struct BYInverter<const L: usize> {
     /// Modulus
-    modulus: ChunkInt<B,L>,
+    modulus: CInt<62, L>,
 
     /// Adjusting parameter
-    adjuster: ChunkInt<B,L>,
+    adjuster: CInt<62, L>,
 
-    /// Multiplicative inverse of the modulus modulo 2^B
-    inverse: i64
+    /// Multiplicative inverse of the modulus modulo 2^62
+    inverse: i64,
 }
 
-/// Type of the Bernstein-Yang transition matrix multiplied by 2^B
+/// Type of the Bernstein-Yang transition matrix multiplied by 2^62
 type Matrix = [[i64; 2]; 2];
 
-impl<const B:usize, const L:usize> BYInverter<B,L> {  
-    fn step(f: &ChunkInt<B,L>, g: &ChunkInt<B,L>, mut delta: i64) -> (i64, Matrix) {
-        let (mut steps, mut f, mut g) = (B as i64, f.lowest() as i64, g.lowest() as i128);
-        let mut matrix: Matrix = [[1, 0], [0, 1]];
+impl<const L: usize> BYInverter<L> {
+    /// Returns the Bernstein-Yang transition matrix multiplied by 2^62 and the new value
+    /// of the delta variable for the 62 basic steps of the Bernstein-Yang method, which
+    /// are to be performed sequentially for specified initial values of f, g and delta
+    fn jump(f: &CInt<62, L>, g: &CInt<62, L>, mut delta: i64) -> (i64, Matrix) {
+        let (mut steps, mut f, mut g) = (62, f.lowest() as i64, g.lowest() as i128);
+        let mut t: Matrix = [[1, 0], [0, 1]];
 
         loop {
             let zeros = steps.min(g.trailing_zeros() as i64);
             (steps, delta, g) = (steps - zeros, delta + zeros, g >> zeros);
-            matrix[0] = [matrix[0][0] << zeros, matrix[0][1] << zeros];
-    
-            if steps == 0  { break; }      
-            
+            t[0] = [t[0][0] << zeros, t[0][1] << zeros];
+
+            if steps == 0 {
+                break;
+            }
             if delta > 0 {
-                (delta, f, g) =  (-delta, g as i64, -f as i128);
-                (matrix[0], matrix[1]) =  (matrix[1], [-matrix[0][0], -matrix[0][1]]);
+                (delta, f, g) = (-delta, g as i64, -f as i128);
+                (t[0], t[1]) = (t[1], [-t[0][0], -t[0][1]]);
             }
 
-            let mask = (1 << steps.min(1 - delta).min(4)) - 1;
-            let w = (g as i64).wrapping_mul(f.wrapping_mul(3) ^ 12) & mask;
-            
-            matrix[1] = [matrix[0][0] * w + matrix[1][0], matrix[0][1] * w + matrix[1][1]];
+            // The formula (3 * x) xor 28 = -1 / x (mod 32) for an odd integer x
+            // in the two's complement code has been derived from the formula
+            // (3 * x) xor 2 = 1 / x (mod 32) attributed to Peter Montgomery
+            let mask = (1 << steps.min(1 - delta).min(5)) - 1;
+            let w = (g as i64).wrapping_mul(f.wrapping_mul(3) ^ 28) & mask;
+
+            t[1] = [t[0][0] * w + t[1][0], t[0][1] * w + t[1][1]];
             g += w as i128 * f as i128;
         }
-    
-        (delta, matrix)
-    }
-    
-    fn fg(f: ChunkInt<B,L>, g: ChunkInt<B,L>, matrix: Matrix) -> (ChunkInt<B,L>, ChunkInt<B,L>) {
-        ((matrix[0][0] * &f + matrix[0][1] * &g).shift(), (matrix[1][0] * &f + matrix[1][1] * &g).shift()) 
+
+        (delta, t)
     }
 
-    fn de(&self, d: ChunkInt<B,L>, e: ChunkInt<B,L>, matrix: Matrix) -> (ChunkInt<B,L>, ChunkInt<B,L>) {
-        let mask = ChunkInt::<B,L>::MASK as i64;
-        let mut md = matrix[0][0] * d.is_negative() as i64 + matrix[0][1] * e.is_negative() as i64;
-        let mut me = matrix[1][0] * d.is_negative() as i64 + matrix[1][1] * e.is_negative() as i64;
+    /// Returns the updated values of the variables f and g for specified initial ones and Bernstein-Yang transition
+    /// matrix multiplied by 2^62. The returned vector is "matrix * (f, g)' / 2^62", where "'" is the transpose operator
+    fn fg(f: CInt<62, L>, g: CInt<62, L>, t: Matrix) -> (CInt<62, L>, CInt<62, L>) {
+        (
+            (t[0][0] * &f + t[0][1] * &g).shift(),
+            (t[1][0] * &f + t[1][1] * &g).shift(),
+        )
+    }
 
-        let cd = matrix[0][0].wrapping_mul(d.lowest() as i64).wrapping_add(matrix[0][1].wrapping_mul(e.lowest() as i64)) & mask; 
-        let ce = matrix[1][0].wrapping_mul(d.lowest() as i64).wrapping_add(matrix[1][1].wrapping_mul(e.lowest() as i64)) & mask;
+    /// Returns the updated values of the variables d and e for specified initial ones and Bernstein-Yang transition
+    /// matrix multiplied by 2^62. The returned vector is congruent modulo M to "matrix * (d, e)' / 2^62 (mod M)",
+    /// where M is the modulus the inverter was created for and "'" stands for the transpose operator. Both the input
+    /// and output values lie in the interval (-2 * M, M)
+    fn de(&self, d: CInt<62, L>, e: CInt<62, L>, t: Matrix) -> (CInt<62, L>, CInt<62, L>) {
+        let mask = CInt::<62, L>::MASK as i64;
+        let mut md = t[0][0] * d.is_negative() as i64 + t[0][1] * e.is_negative() as i64;
+        let mut me = t[1][0] * d.is_negative() as i64 + t[1][1] * e.is_negative() as i64;
+
+        let cd = t[0][0]
+            .wrapping_mul(d.lowest() as i64)
+            .wrapping_add(t[0][1].wrapping_mul(e.lowest() as i64))
+            & mask;
+        let ce = t[1][0]
+            .wrapping_mul(d.lowest() as i64)
+            .wrapping_add(t[1][1].wrapping_mul(e.lowest() as i64))
+            & mask;
 
         md -= (self.inverse.wrapping_mul(cd).wrapping_add(md)) & mask;
         me -= (self.inverse.wrapping_mul(ce).wrapping_add(me)) & mask;
-        
-        let cd = matrix[0][0] * &d + matrix[0][1] * &e + md * &self.modulus;
-        let ce = matrix[1][0] * &d + matrix[1][1] * &e + me * &self.modulus;
 
-        (cd.shift(), ce.shift())   
+        let cd = t[0][0] * &d + t[0][1] * &e + md * &self.modulus;
+        let ce = t[1][0] * &d + t[1][1] * &e + me * &self.modulus;
+
+        (cd.shift(), ce.shift())
     }
 
-    fn norm(&self, mut value: ChunkInt<B,L>, negate: bool) -> ChunkInt<B,L> {
+    /// Returns either "value (mod M)" or "-value (mod M)", where M is the modulus the
+    /// inverter was created for, depending on "negate", which determines the presence
+    /// of "-" in the used formula. The input integer lies in the interval (-2 * M, M)
+    fn norm(&self, mut value: CInt<62, L>, negate: bool) -> CInt<62, L> {
         if value.is_negative() {
             value = value + &self.modulus;
         }
@@ -291,61 +348,77 @@ impl<const B:usize, const L:usize> BYInverter<B,L> {
     /// Returns a big unsigned integer as an array of O-bit chunks, which is equal modulo
     /// 2 ^ (O * S) to the input big unsigned integer stored as an array of I-bit chunks.
     /// The ordering of the chunks in these arrays is little-endian
-    const fn convert<const I:usize, const O:usize, const S:usize>(input: &[u64]) -> [u64; S] {
-        const fn min(a: usize, b: usize) -> usize { if a > b { b } else { a } }
+    const fn convert<const I: usize, const O: usize, const S: usize>(input: &[u64]) -> [u64; S] {
+        // This function is defined because the method "min" of the usize type is not constant
+        const fn min(a: usize, b: usize) -> usize {
+            if a > b {
+                b
+            } else {
+                a
+            }
+        }
+
         let (total, mut output, mut bits) = (min(input.len() * I, S * O), [0; S], 0);
-          
+
         while bits < total {
             let (i, o) = (bits % I, bits % O);
             output[bits / O] |= (input[bits / I] >> i) << o;
             bits += min(I - i, O - o);
         }
-        
+
         let mask = u64::MAX >> (64 - O);
         let mut filled = total / O + if total % O > 0 { 1 } else { 0 };
-    
+
         while filled > 0 {
             filled -= 1;
             output[filled] &= mask;
         }
-        
+
         output
     }
 
-    /// Returns the multiplicative inverse of the argument modulo 2^B. The implementation is based
-    /// on the Hurchalla's method for computing the multiplicative inverse modulo a power of two
+    /// Returns the multiplicative inverse of the argument modulo 2^62. The implementation is based
+    /// on the Hurchalla's method for computing the multiplicative inverse modulo a power of two.
+    /// For better understanding the implementation, the following paper is recommended:
+    /// J. Hurchalla, "An Improved Integer Multiplicative Inverse (modulo 2^w)",
+    /// https://arxiv.org/pdf/2204.04342.pdf
     const fn inv(value: u64) -> i64 {
         let x = value.wrapping_mul(3) ^ 2;
         let y = 1u64.wrapping_sub(x.wrapping_mul(value));
         let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
         let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
         let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
-        (x.wrapping_mul(y.wrapping_add(1)) & ChunkInt::<B,L>::MASK) as i64
+        (x.wrapping_mul(y.wrapping_add(1)) & CInt::<62, L>::MASK) as i64
     }
 
     /// Creates the inverter for specified modulus and adjusting parameter
     pub const fn new(modulus: &[u64], adjuster: &[u64]) -> Self {
         Self {
-            modulus: ChunkInt::<B, L>(Self::convert::<64, B, L>(modulus)), 
-            adjuster: ChunkInt::<B, L>(Self::convert::<64, B, L>(adjuster)),
-            inverse: Self::inv(modulus[0])
+            modulus: CInt::<62, L>(Self::convert::<64, 62, L>(modulus)),
+            adjuster: CInt::<62, L>(Self::convert::<64, 62, L>(adjuster)),
+            inverse: Self::inv(modulus[0]),
         }
     }
-    
-    /// Returns either the adjusted modular multiplicative inverse for the argument or None 
+
+    /// Returns either the adjusted modular multiplicative inverse for the argument or None
     /// depending on invertibility of the argument, i.e. its coprimality with the modulus
-    pub fn invert<const S:usize>(&self, value: &[u64]) -> Option<[u64; S]> {
-        let (mut d, mut e) = (ChunkInt::ZERO, self.adjuster.clone());
-        let mut g = ChunkInt::<B, L>(Self::convert::<64, B, L>(value)); 
+    pub fn invert<const S: usize>(&self, value: &[u64]) -> Option<[u64; S]> {
+        let (mut d, mut e) = (CInt::ZERO, self.adjuster.clone());
+        let mut g = CInt::<62, L>(Self::convert::<64, 62, L>(value));
         let (mut delta, mut f) = (1, self.modulus.clone());
         let mut matrix;
-        while g != ChunkInt::ZERO {
-            (delta, matrix) = Self::step(&f, &g, delta);
+        while g != CInt::ZERO {
+            (delta, matrix) = Self::jump(&f, &g, delta);
             (f, g) = Self::fg(f, g, matrix);
             (d, e) = self.de(d, e, matrix);
         }
-        let antiunit = f == ChunkInt::MINUS_ONE;
-        if (f != ChunkInt::ONE) && !antiunit { return None; }
-        Some(Self::convert::<B, 64, S>(&self.norm(d, antiunit).0))
+        // At this point the absolute value of "f" equals the greatest common divisor
+        // of the integer to be inverted and the modulus the inverter was created for.
+        // Thus, if "f" is neither 1 nor -1, then the sought inverse does not exist
+        let antiunit = f == CInt::MINUS_ONE;
+        if (f != CInt::ONE) && !antiunit {
+            return None;
+        }
+        Some(Self::convert::<62, 64, S>(&self.norm(d, antiunit).0))
     }
 }

--- a/src/bernsteinyang.rs
+++ b/src/bernsteinyang.rs
@@ -1,0 +1,351 @@
+use core::cmp::PartialEq;
+use std::ops::{Add, Mul, Sub, Neg};
+
+/// Big signed (B * L)-bit integer type, whose variables store
+/// numbers in the two's complement code as arrays of B-bit chunks.
+/// The ordering of the chunks in these arrays is little-endian.
+/// The arithmetic operations for this type are wrapping ones.
+#[derive(Clone)]
+struct ChunkInt<const B:usize, const L:usize>(pub [u64; L]);
+
+impl<const B:usize, const L:usize> ChunkInt<B,L> {
+    /// Mask, in which the B lowest bits are 1 and only they
+    pub const MASK: u64 = u64::MAX >> (64 - B);
+
+    /// Representation of 0
+    pub const ZERO: Self = Self([0; L]);
+    
+    /// Representation of 1
+    pub const ONE: Self = { 
+        let mut data = [0; L]; 
+        data[0] = 1; Self(data) 
+    };
+
+    /// Representation of -1
+    pub const MINUS_ONE: Self = Self([Self::MASK; L]);
+
+    /// Returns the result of applying B-bit right
+    /// arithmetical shift to the current number
+    pub fn shift(&self) -> Self {
+        let mut data = [0; L];
+        for i in 1..L {
+            data[i - 1] = self.0[i];
+        }
+        if self.is_negative() {
+            data[L - 1] = Self::MASK;
+        }
+        Self(data)
+    }
+
+    /// Returns the lowest B bits of the current number
+    pub fn lowest(&self) -> u64 { self.0[0] }
+
+    /// Returns "true" iff the current number is negative
+    pub fn is_negative(&self) -> bool {
+        self.0[L - 1] > (Self::MASK >> 1)
+    }
+}
+
+impl <const B:usize, const L:usize> PartialEq for ChunkInt<B,L> {
+    fn eq(&self, other: &Self) -> bool { self.0 == other.0 }
+    fn ne(&self, other: &Self) -> bool { self.0 != other.0 } 
+}
+
+impl<const B:usize, const L:usize> Add for &ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn add(self, other: Self) -> Self::Output {
+        let (mut data, mut carry) = ([0; L], 0);
+        for i in 0..L {
+            let sum = self.0[i] + other.0[i] + carry;
+            data[i] = sum & ChunkInt::<B,L>::MASK;
+            carry = sum >> B;
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const B:usize, const L:usize> Add<&ChunkInt<B,L>> for ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn add(self, other: &Self) -> Self::Output {
+        &self + other
+    }
+}
+
+impl<const B:usize, const L:usize> Add for ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn add(self, other: Self) -> Self::Output {
+        &self + &other
+    }
+}
+
+impl<const B:usize, const L:usize> Sub for &ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn sub(self, other: Self) -> Self::Output {
+        let (mut data, mut carry) = ([0; L], 1);
+        for i in 0..L {
+            let sum = self.0[i] + (other.0[i] ^ ChunkInt::<B,L>::MASK) + carry;
+            data[i] = sum & ChunkInt::<B,L>::MASK;
+            carry = sum >> B;
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const B:usize, const L:usize> Sub<&ChunkInt<B,L>> for ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn sub(self, other: &Self) -> Self::Output {
+        &self - other
+    }
+}
+
+impl<const B:usize, const L:usize> Sub for ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn sub(self, other: Self) -> Self::Output {
+        &self - &other
+    }
+}
+
+impl<const B:usize, const L:usize> Neg for &ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn neg(self) -> Self::Output {
+        let (mut data, mut carry) = ([0; L], 1);
+        for i in 0..L {
+            let sum = (self.0[i] ^ ChunkInt::<B,L>::MASK) + carry;
+            data[i] = sum & ChunkInt::<B,L>::MASK;
+            carry = sum >> B;
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const B:usize, const L:usize> Neg for ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn neg(self) -> Self::Output {
+        -&self
+    }
+}
+
+impl<const B:usize, const L:usize> Mul for &ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn mul(self, other: Self) -> Self::Output {
+        let mut data = [0; L];
+        for i in 0..L {
+            let mut carry = 0;
+            for k in 0..(L - i) {
+                let sum = (data[i + k] as u128) + (carry as u128) +
+                    (self.0[i] as u128) * (other.0[k] as u128);
+                data[i + k] = sum as u64 & ChunkInt::<B,L>::MASK;
+                carry = (sum >> B) as u64;
+            }
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const B:usize, const L:usize> Mul<&ChunkInt<B,L>> for ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn mul(self, other: &Self) -> Self::Output {
+        &self * other
+    }
+}
+
+impl<const B:usize, const L:usize> Mul for ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn mul(self, other: Self) -> Self::Output {
+        &self * &other
+    }
+}
+
+impl<const B:usize, const L:usize> Mul<i64> for &ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn mul(self, other: i64) -> Self::Output {
+        let mut data = [0; L];
+        let (other, mut carry, mask) = if other < 0 { 
+            (-other, -other as u64, ChunkInt::<B,L>::MASK) 
+        } else { (other, 0, 0) };
+        for i in 0..L {
+            let sum = (carry as u128) + ((self.0[i] ^ mask) as u128) * (other as u128);
+            data[i] = sum as u64 & ChunkInt::<B,L>::MASK;
+            carry = (sum >> B) as u64;
+        }
+        Self::Output { 0: data }
+    }
+}
+
+impl<const B:usize, const L:usize> Mul<i64> for ChunkInt<B,L> {
+    type Output = ChunkInt<B,L>;
+    fn mul(self, other: i64) -> Self::Output {
+        &self * other
+    }
+}
+
+impl<const B:usize, const L:usize> Mul<&ChunkInt<B,L>> for i64 {
+    type Output = ChunkInt<B,L>;
+    fn mul(self, other: &ChunkInt<B,L>) -> Self::Output {
+        other * self 
+    }
+}
+
+impl<const B:usize, const L:usize> Mul<ChunkInt<B,L>> for i64 {
+    type Output = ChunkInt<B,L>;
+    fn mul(self, other: ChunkInt<B,L>) -> Self::Output {
+        other * self 
+    }
+}
+
+/// Type of the modular multiplicative inverter based on the Bernstein-Yang method.
+/// The inverter can be created for a specified modulus M and adjusting parameter A 
+/// to compute the adjusted multiplicative inverses of positive integers, i.e. for 
+/// computing (1 / x) * A mod M for a positive integer x.
+///
+/// The adjusting parameter allows computing the multiplicative inverses in the case of
+/// using the Montgomery representation for the input or the expected output. If R is 
+/// the Montgomery factor, the multiplicative inverses in the appropriate representation
+/// can be computed provided that the value of A is chosen as follows:
+/// - A = 1, if both the input and the expected output are in the trivial form
+/// - A = R^2 mod M, if both the input and the expected output are in the Montgomery form
+/// - A = R mod M, if either the input or the expected output is in the Montgomery form,
+/// but not both of them
+/// 
+/// The public methods of this type receive and return unsigned big integers as arrays of
+/// 64-bit chunks, the ordering of which is little-endian. Both the modulus and the integer
+/// to be inverted should not exceed 2 ^ (B * (L - 1) - 2)
+pub struct BYInverter<const B:usize, const L:usize> {
+    /// Modulus
+    modulus: ChunkInt<B,L>,
+
+    /// Adjusting parameter
+    adjuster: ChunkInt<B,L>,
+
+    /// Multiplicative inverse of the modulus modulo 2^B
+    inverse: i64
+}
+
+/// Type of the Bernstein-Yang transition matrix multiplied by 2^B
+type Matrix = [[i64; 2]; 2];
+
+impl<const B:usize, const L:usize> BYInverter<B,L> {  
+    fn step(f: &ChunkInt<B,L>, g: &ChunkInt<B,L>, mut delta: i64) -> (i64, Matrix) {
+        let (mut steps, mut f, mut g) = (B as i64, f.lowest() as i64, g.lowest() as i128);
+        let mut matrix: Matrix = [[1, 0], [0, 1]];
+
+        loop {
+            let zeros = steps.min(g.trailing_zeros() as i64);
+            (steps, delta, g) = (steps - zeros, delta + zeros, g >> zeros);
+            matrix[0] = [matrix[0][0] << zeros, matrix[0][1] << zeros];
+    
+            if steps == 0  { break; }      
+            
+            if delta > 0 {
+                (delta, f, g) =  (-delta, g as i64, -f as i128);
+                (matrix[0], matrix[1]) =  (matrix[1], [-matrix[0][0], -matrix[0][1]]);
+            }
+
+            let mask = (1 << steps.min(1 - delta).min(4)) - 1;
+            let w = (g as i64).wrapping_mul(f.wrapping_mul(3) ^ 12) & mask;
+            
+            matrix[1] = [matrix[0][0] * w + matrix[1][0], matrix[0][1] * w + matrix[1][1]];
+            g += w as i128 * f as i128;
+        }
+    
+        (delta, matrix)
+    }
+    
+    fn fg(f: ChunkInt<B,L>, g: ChunkInt<B,L>, matrix: Matrix) -> (ChunkInt<B,L>, ChunkInt<B,L>) {
+        ((matrix[0][0] * &f + matrix[0][1] * &g).shift(), (matrix[1][0] * &f + matrix[1][1] * &g).shift()) 
+    }
+
+    fn de(&self, d: ChunkInt<B,L>, e: ChunkInt<B,L>, matrix: Matrix) -> (ChunkInt<B,L>, ChunkInt<B,L>) {
+        let mask = ChunkInt::<B,L>::MASK as i64;
+        let mut md = matrix[0][0] * d.is_negative() as i64 + matrix[0][1] * e.is_negative() as i64;
+        let mut me = matrix[1][0] * d.is_negative() as i64 + matrix[1][1] * e.is_negative() as i64;
+
+        let cd = matrix[0][0].wrapping_mul(d.lowest() as i64).wrapping_add(matrix[0][1].wrapping_mul(e.lowest() as i64)) & mask; 
+        let ce = matrix[1][0].wrapping_mul(d.lowest() as i64).wrapping_add(matrix[1][1].wrapping_mul(e.lowest() as i64)) & mask;
+
+        md -= (self.inverse.wrapping_mul(cd).wrapping_add(md)) & mask;
+        me -= (self.inverse.wrapping_mul(ce).wrapping_add(me)) & mask;
+        
+        let cd = matrix[0][0] * &d + matrix[0][1] * &e + md * &self.modulus;
+        let ce = matrix[1][0] * &d + matrix[1][1] * &e + me * &self.modulus;
+
+        (cd.shift(), ce.shift())   
+    }
+
+    fn norm(&self, mut value: ChunkInt<B,L>, negate: bool) -> ChunkInt<B,L> {
+        if value.is_negative() {
+            value = value + &self.modulus;
+        }
+
+        if negate {
+            value = -value;
+        }
+
+        if value.is_negative() {
+            value = value + &self.modulus;
+        }
+
+        value
+    }
+
+    /// Returns a big unsigned integer as an array of O-bit chunks, which is equal modulo
+    /// 2 ^ (O * S) to the input big unsigned integer stored as an array of I-bit chunks.
+    /// The ordering of the chunks in these arrays is little-endian
+    const fn convert<const I:usize, const O:usize, const S:usize>(input: &[u64]) -> [u64; S] {
+        const fn min(a: usize, b: usize) -> usize { if a > b { b } else { a } }
+        let (total, mut output, mut bits) = (min(input.len() * I, S * O), [0; S], 0);
+          
+        while bits < total {
+            let (i, o) = (bits % I, bits % O);
+            output[bits / O] |= (input[bits / I] >> i) << o;
+            bits += min(I - i, O - o);
+        }
+        
+        let mask = u64::MAX >> (64 - O);
+        let mut filled = total / O + if total % O > 0 { 1 } else { 0 };
+    
+        while filled > 0 {
+            filled -= 1;
+            output[filled] &= mask;
+        }
+        
+        output
+    }
+
+    /// Returns the multiplicative inverse of the argument modulo 2^B. The implementation is based
+    /// on the Hurchalla's method for computing the multiplicative inverse modulo a power of two
+    const fn inv(value: u64) -> i64 {
+        let x = value.wrapping_mul(3) ^ 2;
+        let y = 1u64.wrapping_sub(x.wrapping_mul(value));
+        let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
+        let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
+        let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
+        (x.wrapping_mul(y.wrapping_add(1)) & ChunkInt::<B,L>::MASK) as i64
+    }
+
+    /// Creates the inverter for specified modulus and adjusting parameter
+    pub const fn new(modulus: &[u64], adjuster: &[u64]) -> Self {
+        Self {
+            modulus: ChunkInt::<B, L>(Self::convert::<64, B, L>(modulus)), 
+            adjuster: ChunkInt::<B, L>(Self::convert::<64, B, L>(adjuster)),
+            inverse: Self::inv(modulus[0])
+        }
+    }
+    
+    /// Returns either the adjusted modular multiplicative inverse for the argument or None 
+    /// depending on invertibility of the argument, i.e. its coprimality with the modulus
+    pub fn invert<const S:usize>(&self, value: &[u64]) -> Option<[u64; S]> {
+        let (mut d, mut e) = (ChunkInt::ZERO, self.adjuster.clone());
+        let mut g = ChunkInt::<B, L>(Self::convert::<64, B, L>(value)); 
+        let (mut delta, mut f) = (1, self.modulus.clone());
+        let mut matrix;
+        while g != ChunkInt::ZERO {
+            (delta, matrix) = Self::step(&f, &g, delta);
+            (f, g) = Self::fg(f, g, matrix);
+            (d, e) = self.de(d, e, matrix);
+        }
+        let antiunit = f == ChunkInt::MINUS_ONE;
+        if (f != ChunkInt::ONE) && !antiunit { return None; }
+        Some(Self::convert::<B, 64, S>(&self.norm(d, antiunit).0))
+    }
+}

--- a/src/bn256/fq.rs
+++ b/src/bn256/fq.rs
@@ -219,7 +219,9 @@ impl ff::Field for Fq {
 
     /// Returns the multiplicative inverse of the
     /// element. If it is zero, the method fails.
-    fn invert(&self) -> CtOption<Self> { self.invert() }
+    fn invert(&self) -> CtOption<Self> {
+        self.invert()
+    }
 }
 
 impl ff::PrimeField for Fq {

--- a/src/bn256/fq.rs
+++ b/src/bn256/fq.rs
@@ -217,18 +217,9 @@ impl ff::Field for Fq {
         ff::helpers::sqrt_ratio_generic(num, div)
     }
 
-    /// Computes the multiplicative inverse of this element,
-    /// failing if the element is zero.
-    fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow([
-            0x3c208c16d87cfd45,
-            0x97816a916871ca8d,
-            0xb85045b68181585d,
-            0x30644e72e131a029,
-        ]);
-
-        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
-    }
+    /// Returns the multiplicative inverse of the
+    /// element. If it is zero, the method fails.
+    fn invert(&self) -> CtOption<Self> { self.invert() }
 }
 
 impl ff::PrimeField for Fq {

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -233,7 +233,9 @@ impl ff::Field for Fr {
 
     /// Returns the multiplicative inverse of the
     /// element. If it is zero, the method fails.
-    fn invert(&self) -> CtOption<Self> { self.invert() }
+    fn invert(&self) -> CtOption<Self> {
+        self.invert()
+    }
 
     fn sqrt(&self) -> CtOption<Self> {
         /// `(t - 1) // 2` where t * 2^s + 1 = p with t odd.

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -231,18 +231,9 @@ impl ff::Field for Fr {
         self.square()
     }
 
-    /// Computes the multiplicative inverse of this element,
-    /// failing if the element is zero.
-    fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow([
-            0x43e1f593efffffff,
-            0x2833e84879b97091,
-            0xb85045b68181585d,
-            0x30644e72e131a029,
-        ]);
-
-        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
-    }
+    /// Returns the multiplicative inverse of the
+    /// element. If it is zero, the method fails.
+    fn invert(&self) -> CtOption<Self> { self.invert() }
 
     fn sqrt(&self) -> CtOption<Self> {
         /// `(t - 1) // 2` where t * 2^s + 1 = p with t odd.

--- a/src/derive/field.rs
+++ b/src/derive/field.rs
@@ -24,6 +24,11 @@ macro_rules! field_common {
         $r2:ident,
         $r3:ident
     ) => {
+        /// Bernstein-Yang modular multiplicative inverter created for the modulus equal to
+        /// the characteristic of the field to invert positive integers in the Montgomery form.
+        const BYINVERTOR: crate::bernsteinyang::BYInverter<62,6> = 
+            crate::bernsteinyang::BYInverter::<62,6>::new(&$modulus.0, &$r2.0);
+
         impl $field {
             /// Returns zero, the additive identity.
             #[inline]
@@ -35,6 +40,16 @@ macro_rules! field_common {
             #[inline]
             pub const fn one() -> $field {
                 $r
+            }
+
+            /// Returns the multiplicative inverse of the
+            /// element. If it is zero, the method fails.
+            pub fn invert(&self) -> CtOption<Self> {
+                if let Some(inverse) = BYINVERTOR.invert(&self.0) {
+                    CtOption::new(Self(inverse), Choice::from(1))
+                } else {
+                    CtOption::new(Self::zero(), Choice::from(0))
+                }
             }
 
             fn from_u512(limbs: [u64; 8]) -> $field {
@@ -339,6 +354,7 @@ macro_rules! field_common {
 macro_rules! field_arithmetic {
     ($field:ident, $modulus:ident, $inv:ident, $field_type:ident) => {
         field_specific!($field, $modulus, $inv, $field_type);
+
         impl $field {
             /// Doubles this field element.
             #[inline]

--- a/src/derive/field.rs
+++ b/src/derive/field.rs
@@ -26,8 +26,8 @@ macro_rules! field_common {
     ) => {
         /// Bernstein-Yang modular multiplicative inverter created for the modulus equal to
         /// the characteristic of the field to invert positive integers in the Montgomery form.
-        const BYINVERTOR: crate::bernsteinyang::BYInverter<62,6> = 
-            crate::bernsteinyang::BYInverter::<62,6>::new(&$modulus.0, &$r2.0);
+        const BYINVERTOR: $crate::bernsteinyang::BYInverter<6> =
+            $crate::bernsteinyang::BYInverter::<6>::new(&$modulus.0, &$r2.0);
 
         impl $field {
             /// Returns zero, the additive identity.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod arithmetic;
+mod bernsteinyang;
 pub mod hash_to_curve;
 pub mod serde;
 

--- a/src/secp256k1/fp.rs
+++ b/src/secp256k1/fp.rs
@@ -181,7 +181,9 @@ impl ff::Field for Fp {
 
     /// Returns the multiplicative inverse of the
     /// element. If it is zero, the method fails.
-    fn invert(&self) -> CtOption<Self> { self.invert() }
+    fn invert(&self) -> CtOption<Self> {
+        self.invert()
+    }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {
         let mut res = Self::one();

--- a/src/secp256k1/fp.rs
+++ b/src/secp256k1/fp.rs
@@ -179,18 +179,9 @@ impl ff::Field for Fp {
         CtOption::new(tmp, tmp.square().ct_eq(self))
     }
 
-    /// Computes the multiplicative inverse of this element,
-    /// failing if the element is zero.
-    fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow_vartime([
-            0xfffffffefffffc2d,
-            0xffffffffffffffff,
-            0xffffffffffffffff,
-            0xffffffffffffffff,
-        ]);
-
-        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
-    }
+    /// Returns the multiplicative inverse of the
+    /// element. If it is zero, the method fails.
+    fn invert(&self) -> CtOption<Self> { self.invert() }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {
         let mut res = Self::one();

--- a/src/secp256k1/fq.rs
+++ b/src/secp256k1/fq.rs
@@ -179,18 +179,9 @@ impl ff::Field for Fq {
         self.square()
     }
 
-    /// Computes the multiplicative inverse of this element,
-    /// failing if the element is zero.
-    fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow_vartime([
-            0xbfd25e8cd036413f,
-            0xbaaedce6af48a03b,
-            0xfffffffffffffffe,
-            0xffffffffffffffff,
-        ]);
-
-        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
-    }
+    /// Returns the multiplicative inverse of the
+    /// element. If it is zero, the method fails.
+    fn invert(&self) -> CtOption<Self> { self.invert() }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {
         let mut res = Self::one();

--- a/src/secp256k1/fq.rs
+++ b/src/secp256k1/fq.rs
@@ -181,7 +181,9 @@ impl ff::Field for Fq {
 
     /// Returns the multiplicative inverse of the
     /// element. If it is zero, the method fails.
-    fn invert(&self) -> CtOption<Self> { self.invert() }
+    fn invert(&self) -> CtOption<Self> {
+        self.invert()
+    }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {
         let mut res = Self::one();

--- a/src/secp256r1/fp.rs
+++ b/src/secp256r1/fp.rs
@@ -197,18 +197,9 @@ impl ff::Field for Fp {
         CtOption::new(tmp, tmp.square().ct_eq(self))
     }
 
-    /// Computes the multiplicative inverse of this element,
-    /// failing if the element is zero.
-    fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow_vartime([
-            0xfffffffffffffffd,
-            0x00000000ffffffff,
-            0x0000000000000000,
-            0xffffffff00000001,
-        ]);
-
-        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
-    }
+    /// Returns the multiplicative inverse of the
+    /// element. If it is zero, the method fails.
+    fn invert(&self) -> CtOption<Self> { self.invert() }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {
         let mut res = Self::one();

--- a/src/secp256r1/fp.rs
+++ b/src/secp256r1/fp.rs
@@ -199,7 +199,9 @@ impl ff::Field for Fp {
 
     /// Returns the multiplicative inverse of the
     /// element. If it is zero, the method fails.
-    fn invert(&self) -> CtOption<Self> { self.invert() }
+    fn invert(&self) -> CtOption<Self> {
+        self.invert()
+    }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {
         let mut res = Self::one();

--- a/src/secp256r1/fq.rs
+++ b/src/secp256r1/fq.rs
@@ -176,7 +176,9 @@ impl ff::Field for Fq {
 
     /// Returns the multiplicative inverse of the
     /// element. If it is zero, the method fails.
-    fn invert(&self) -> CtOption<Self> { self.invert() }
+    fn invert(&self) -> CtOption<Self> {
+        self.invert()
+    }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {
         let mut res = Self::one();

--- a/src/secp256r1/fq.rs
+++ b/src/secp256r1/fq.rs
@@ -174,18 +174,9 @@ impl ff::Field for Fq {
         self.square()
     }
 
-    /// Computes the multiplicative inverse of this element,
-    /// failing if the element is zero.
-    fn invert(&self) -> CtOption<Self> {
-        let tmp = self.pow_vartime([
-            0xf3b9cac2fc63254f,
-            0xbce6faada7179e84,
-            0xffffffffffffffff,
-            0xffffffff00000000,
-        ]);
-
-        CtOption::new(tmp, !self.ct_eq(&Self::zero()))
-    }
+    /// Returns the multiplicative inverse of the
+    /// element. If it is zero, the method fails.
+    fn invert(&self) -> CtOption<Self> { self.invert() }
 
     fn pow_vartime<S: AsRef<[u64]>>(&self, exp: S) -> Self {
         let mut res = Self::one();


### PR DESCRIPTION
Replacing the multiplicative inversion based on the Little Fermat Theorem with Bernstein yang multiplicative inversion. The latter one turned out to be about 8.5 times faster on average.